### PR TITLE
Fix #3007: Changed description of explicit TLS

### DIFF
--- a/docs/content/config/security/understanding-the-ports.md
+++ b/docs/content/config/security/understanding-the-ports.md
@@ -66,7 +66,7 @@ flowchart LR
 
 #### Explicit TLS (aka Opportunistic TLS) - Opt-in Encryption
 
-Communication on these ports begin in [cleartext][ref-clear-vs-plain], indicating support for `STARTTLS`. If both client and server support `STARTTLS` the connection will be secured over TLS, otherwise no encryption will be used.
+Communication on these ports begin in [cleartext][ref-clear-vs-plain], indicating support for `STARTTLS`. If both client and server support `STARTTLS` the connection will be secured over TLS, otherwise usually no encryption will be used. But `docker-mailserver` will reject a connection that cannot be secured.
 
 Support for `STARTTLS` is not always implemented correctly, which can lead to leaking credentials(client sending too early) prior to a TLS connection being established. Third-parties such as some ISPs have also been known to intercept the `STARTTLS` exchange, modifying network traffic to prevent establishing a secure connection.
 


### PR DESCRIPTION
Changed description of explicit TLS to indicate that insecure connections are rejected

# Description
Fixes #3007

## Type of change
- [ X] Clearification of documentation